### PR TITLE
hs-airdrop: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node
+COPY . .
+ENV BUILD_DIR hs-tree-data
+RUN npm i & git clone https://github.com/handshake-org/hs-tree-data.git
+ENTRYPOINT ["./bin/hs-airdrop"]


### PR DESCRIPTION
This will be automatically built and published on [Docker Hub](https://cloud.docker.com/u/namebase/repository/docker/namebase/hs-airdrop)

Then, you can use the tool in non-networked container with read-only access to your private key.
```
docker pull namebase/hs-airdrop && docker run -it --network none -v ~/.ssh/<id_github>:/private_key:ro namebase/hs-airdrop private_key <address> <fee>
```

https://github.com/handshake-org/hs-airdrop/issues/17 #1 